### PR TITLE
chore: limit CI test job concurrency to 1

### DIFF
--- a/.azure-pipelines/common/build.yml
+++ b/.azure-pipelines/common/build.yml
@@ -96,6 +96,7 @@ jobs:
       --distdir=$(Pipeline.Workspace)/distdir
       --compilation_mode opt
       --config=clang-asan
+      --local_test_jobs=1
       --
       //...
     displayName: Test project


### PR DESCRIPTION
According to Azure Pipeline document, the Microsoft-hosted agents has only 2 core CPU, 7 GB of RAM. Limit the test job concurrency to avoid heartbeat disconnected issue for the agent.