### PR TITLE
chore: migrate hedron_compile_commands to module registry

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,7 +31,7 @@ bazel_dep(name = "toolchains_llvm", version = "1.0.0", dev_dependency = True)
 # Configure and register the toolchain.
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
-   llvm_version = "17.0.6",
+    llvm_version = "17.0.6",
 )
 
 use_repo(llvm, "llvm_toolchain")
@@ -93,9 +93,4 @@ bazel_dep(name = "google_benchmark", version = "1.8.5", dev_dependency = True)
 #
 #   bazel run @hedron_compile_commands//:refresh_all
 #
-bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
-git_override(
-    module_name = "hedron_compile_commands",
-    commit = "a14ad3a64e7bf398ab48105aaa0348e032ac87f8",
-    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
-)
+bazel_dep(name = "hedron_compile_commands", version = "20240628.1", dev_dependency = True)

--- a/one-central-registry/modules/hedron_compile_commands/20240628.1/MODULE.bazel
+++ b/one-central-registry/modules/hedron_compile_commands/20240628.1/MODULE.bazel
@@ -1,0 +1,31 @@
+# Copyright (c) 2022 Zhang Shuai<zhangshuai.ustc@gmail.com>.
+# All rights reserved.
+#
+# This file is part of ONE.
+#
+# ONE is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# ONE is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# ONE. If not, see <https://www.gnu.org/licenses/>.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# Further, this license will terminate automatically and without notice if you file a lawsuit against Hedron. More generally, this is a revocable license.
+
+module(
+    name = "hedron_compile_commands",
+    version = "20240628.1",
+    compatibility_level = 1,
+)
+
+p = use_extension("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_extension")
+pt = use_extension("@hedron_compile_commands//:workspace_setup_transitive.bzl", "hedron_compile_commands_extension")
+ptt = use_extension("@hedron_compile_commands//:workspace_setup_transitive_transitive.bzl", "hedron_compile_commands_extension")
+pttt = use_extension("@hedron_compile_commands//:workspace_setup_transitive_transitive_transitive.bzl", "hedron_compile_commands_extension")

--- a/one-central-registry/modules/hedron_compile_commands/20240628.1/source.json
+++ b/one-central-registry/modules/hedron_compile_commands/20240628.1/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/1e08f8e0507b6b6b1f4416a9a22cf5c28beaba93.tar.gz",
+    "integrity": "sha256-BEsUixEeF87mHYw6ru1CBp9zJUYDgjQK/KSRn4JlCUw=",
+    "strip_prefix": "bazel-compile-commands-extractor-1e08f8e0507b6b6b1f4416a9a22cf5c28beaba93"
+}

--- a/one-central-registry/modules/hedron_compile_commands/metadata.json
+++ b/one-central-registry/modules/hedron_compile_commands/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/hedronvision/bazel-compile-commands-extractor",
+    "maintainers": [
+        {
+            "email": "zhangshuai.ustc@gmail.com",
+            "github": "hcoona",
+            "name": "Shuai Zhang"
+        }
+    ],
+    "repository": [
+        "github:hedronvision/bazel-compile-commands-extractor"
+    ],
+    "versions": [
+        "20240628.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
To avoid git clone (either shallow or deep).